### PR TITLE
+alpine -ubuntu base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,4 @@
-FROM ubuntu:latest
-RUN apt-get update && \
-    apt-get upgrade -y && \
-    apt-get install -y wget unzip
+FROM alpine:latest
 RUN wget https://downloads.lambdatest.com/tunnel/v3/linux/64bit/LT_Linux.zip && \ 
     unzip LT_Linux.zip && \
     rm LT_Linux.zip && \


### PR DESCRIPTION
With ubuntu as base image, the complete image size is around 125MB, but when alpine is used the base image size reduces to around 21MB. Please see the below picture for more reference.

![Screenshot from 2021-05-18 19-08-20](https://user-images.githubusercontent.com/68378643/118661147-7e1ed400-b80c-11eb-98f7-d0c93cfa1d47.png)
